### PR TITLE
Change the OpenStackControlPlane name to match the RHOSO 18.0 public Docs

### DIFF
--- a/content/files/osp-ng-ctlplane-deploy.yaml
+++ b/content/files/osp-ng-ctlplane-deploy.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.openstack.org/v1beta1
 kind: OpenStackControlPlane
 metadata:
-  name: openstack-galera-network-isolation
+  name: openstack-control-plane
 spec:
   secret: osp-secret
   storageClass: ocs-storagecluster-ceph-rbd


### PR DESCRIPTION
Replace "openstack-galera-network-isolation" with "openstack-control-plane" to be consistent with RHOSO 18.0 public install doc.